### PR TITLE
Tolerate empty domain name during hostname initialization.

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-base-initialize-db
+++ b/root/etc/e-smith/events/actions/nethserver-base-initialize-db
@@ -152,12 +152,13 @@ chomp($timezone);
 $cdb->set_value('TimeZone', $timezone);
 
 # Read hostname
-my($system_name, $domain_name) = split(m/\./, (`hostnamectl --static` || `hostnamectl --transient` || `/bin/hostname`), 2);
+my($system_name, $domain_name) = split(m/\./, (`hostnamectl --static` || `hostnamectl --transient` || `/bin/hostname`), 2), '', '';
 
+chomp($system_name);
 chomp($domain_name);
 
-$cdb->set_value('SystemName', $system_name);
-$cdb->set_value('DomainName', $domain_name);
+$cdb->set_value('SystemName', $system_name || "localhost");
+$cdb->set_value('DomainName', $domain_name || "localdomain");
 
 # Grab all ethernet interfaces
 initialize_networks_db();


### PR DESCRIPTION
Some VPS providers set empty domain name on their CentOS images.

See http://community.nethserver.org/t/problem-on-install-ns7-on-digital-ocean/2935/3?u=davidep