### PR TITLE
Enforce the host name length NetBIOS limit NethServer/dev#5110

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -266,4 +266,7 @@ event_templates('proxy-modify', qw(
 ));
 
 
-exit 0;
+validator_actions('myhostname', qw(
+    hostname-length 10
+));
+

--- a/nethserver-base.spec
+++ b/nethserver-base.spec
@@ -40,7 +40,6 @@ mkdir -p root%{perl_vendorlib}
 mv -v lib/perl/{NethServer,esmith} root%{perl_vendorlib}
 mkdir -p root/%{_nseventsdir}/organization-save
 mkdir -p root/%{_nseventsdir}/%{name}-update
-mkdir -p root/%{_nsconfdir}/validators/myhostname
 
 for _nsdb in configuration networks routes accounts; do
    mkdir -p root/%{_nsdbconfdir}/${_nsdb}/{migrate,force,defaults}
@@ -68,7 +67,6 @@ rm -rf %{buildroot}
 %dir %{_nsdbconfdir}/networks
 %dir %{_nsdbconfdir}/routes
 %dir %{_nsdbconfdir}/accounts
-%dir %{_nsconfdir}/validators/myhostname
 %ghost %attr(0644,root,root) /etc/logviewer.conf
 %config(noreplace) %{_sysconfdir}/nethserver/pkginfo.conf
 

--- a/root/etc/e-smith/validators/actions/hostname-length
+++ b/root/etc/e-smith/validators/actions/hostname-length
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2016 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+H=$(echo "$1" | cut -d. -f1)
+
+# NetBIOS length limit for hostname H
+if (( ${#H} > 15 || ${#H} == 0 )); then
+    exit 3
+fi
+
+# Check it is composed by "letters, digits, hyphens, and periods":
+if [[ -n "$(tr -d '[:alnum:].-' <<< ${H})" ]]; then
+    exit 4
+fi
+
+exit 0

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_FQDN.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_FQDN.php
@@ -10,3 +10,5 @@ $L['SystemName_label'] = 'Hostname';
 $L['DomainName_label'] = 'Domain';
 $L['FQDN_label'] = 'Fully qualified domain name';
 $L['valid_platform,myhostname,failifjoin,1'] = 'Users and groups provider already configured';
+$L['valid_platform,myhostname,hostname-length,3'] = 'The host name part length must be up to 15 characters long';
+$L['valid_platform,myhostname,hostname-length,4'] = 'Only letters, digits and hyphens are allowed in the host name part';


### PR DESCRIPTION
No more than 15 chars are allowed in NetBIOS computer names. Allowed
chars are letters, digits, hyphens, and periods. NethServer/dev#5110