### PR TITLE
nic-info: avoid errors with kernel 4.4.x

### DIFF
--- a/root/usr/libexec/nethserver/bond-slave-mac
+++ b/root/usr/libexec/nethserver/bond-slave-mac
@@ -16,7 +16,7 @@ my $eth = $ARGV[1] || die(help);
 
 my $filename = "/proc/net/bonding/$bond";
 open(my $fh, '<', $filename)
-  or die "No such file: '$filename' $!";
+  or exit 1;
 
 my $found = 0;
 while (my $row = <$fh>) {

--- a/root/usr/libexec/nethserver/nic-info
+++ b/root/usr/libexec/nethserver/nic-info
@@ -64,7 +64,7 @@ for card in ${cards[@]}; do
         continue
     fi
 
-    if [ -d /sys/class/net/${card}/master ]; then
+    if [ -d /sys/class/net/${card}/master ] && [ ! -d /sys/class/net/${card}/brport ]; then
         link=`/bin/readlink  /sys/class/net/${card}/master`
         bond=`basename $link`
         hwaddr=`/usr/libexec/nethserver/bond-slave-mac ${bond} ${card}`


### PR DESCRIPTION
In kernel 4.4.x bridged cards have a master links inside `/sys/class/net/` like bonds.
To avoid wrong mac address detection we must check also for a link called `brport` (only for bridges).

NethServer/dev#5123
