### PR TITLE
Hide clear-text passwords in /var/log/secure NethServer/dev#5130

### DIFF
--- a/root/etc/e-smith/validators/actions/password-strength
+++ b/root/etc/e-smith/validators/actions/password-strength
@@ -24,16 +24,21 @@ use strict;
 use esmith::ConfigDB;
 
 my $objectType = shift;
-my $password = shift;
+my $passwordFile = shift;
 my $reason;
 
 if( ! defined $objectType ) {
     die "Missing objectType argument";
 }
 
-if( ! defined $password ) {
-    die "Missing password argument";
+if( ! defined $passwordFile ) {
+    die "Missing passwordFile argument";
 }
+
+open(PWFILE, '<', $passwordFile) or die("[ERROR] Cannot read password from temporary file\n");
+my $password = <PWFILE>;
+chomp($password);
+close(PWFILE);
 
 my $configDb = esmith::ConfigDB->open_ro();
 my $strength = $configDb->get_prop('passwordstrength', $objectType);
@@ -49,7 +54,7 @@ if ( ! defined $strength ) {
     exit 0;
 
 } elsif( $strength eq 'strong') {
-    exit 5 if (not $password =~ /\d/); #missing digit
+    exit 5 if ($password !~ /\d/); #missing digit
     exit 6 if ($password !~ /[A-Z]/); #missing capital
     exit 7 if ($password !~ /[a-z]/); #missing lowercase
     exit 8 if ($password !~ /\W|_/); #missing symbol


### PR DESCRIPTION
Root privileges are required to read /var/log/secure, however a password
must always be secret.

NethServer/dev#5130