### PR TITLE
Adjust fixnetwork flag file during interface-update

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -62,6 +62,7 @@ event_services('nethserver-base-update', qw(
 event_actions('interface-update', qw(
               network-stop               04
               interface-rename           20
+              adjust-fixnetwork-flag     21
               interface-config-reset     25
               interface-config-write     30
               network-start              70

--- a/root/etc/e-smith/events/actions/adjust-fixnetwork-flag
+++ b/root/etc/e-smith/events/actions/adjust-fixnetwork-flag
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+flag=/var/run/.nethserver-fixnetwork
+output=$(/usr/libexec/nethserver/eth-unmapped)
+
+if [[ $output == "[]" ]]; then
+    if [[ -f $flag ]]; then
+        rm -f $flag
+        echo "[NOTICE] network configuration seems good flag $flag cleared!"
+    fi
+elif [[ ! -f $flag ]]; then
+    touch $flag
+    echo "[WARNING] bad network configuration detected flag $flag set!"
+fi

--- a/root/etc/e-smith/events/actions/network-start
+++ b/root/etc/e-smith/events/actions/network-start
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/sbin/service network start
+exec systemctl start network

--- a/root/etc/e-smith/events/actions/network-stop
+++ b/root/etc/e-smith/events/actions/network-stop
@@ -25,9 +25,6 @@ use strict;
 
 system(qw(systemctl stop network));
 
-our $output_dir = $output_dir || $ENV{ESMITH_NETWORK_OUT_DIR} || "/etc/sysconfig/network-scripts";
-
-my %current = {};
 # Query the currently active interfaces:
 foreach (split(/\n/, `ip -o link`)) {
    my ($id, $name, $details) = split(/:/, $_);

--- a/root/etc/e-smith/events/actions/network-stop
+++ b/root/etc/e-smith/events/actions/network-stop
@@ -23,7 +23,7 @@
 use esmith::NetworksDB;
 use strict;
 
-qx(/sbin/service network stop);
+system(qw(systemctl stop network));
 
 our $output_dir = $output_dir || $ENV{ESMITH_NETWORK_OUT_DIR} || "/etc/sysconfig/network-scripts";
 


### PR DESCRIPTION
The ``adjust-fixnetwork-flag`` checks the state of network configuration with ``/usr/libexec/nethserver/eth-unmapped`` and set/unset the ``/var/run/.nethserver-fixnetwork`` flag accordingly.

NethServer/dev#5193