### PR TITLE
Remove legacy call to network-create event

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -23,7 +23,6 @@ use esmith::Build::CreateLinks  qw(:all);
 use File::Path;
 
 event_actions('trusted-networks-modify', qw(
-    legacy-call-network-create 10
     firewall-adjust 94
 ));
 

--- a/root/etc/e-smith/events/actions/legacy-call-network-create
+++ b/root/etc/e-smith/events/actions/legacy-call-network-create
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-if [ -d "/etc/e-smith/events/network-create" ]; then
-    exec /sbin/e-smith/signal-event network-create $*
-fi


### PR DESCRIPTION
Modules must bind to trusted-networks-modify event.

See also NethServer/nethserver-roundcubemail#9