### PR TITLE
getRealUser(): fix fully-qualified user name

### DIFF
--- a/root/usr/share/nethesis/NethServer/Tool/ChangePassword.php
+++ b/root/usr/share/nethesis/NethServer/Tool/ChangePassword.php
@@ -111,6 +111,10 @@ class ChangePassword extends \Nethgui\Controller\Table\AbstractAction
 
     private function getRealUser( $user )
     {
+        if(strstr($user, '@')) {
+            return $user; // return full user name as-is
+        }
+
         $passwd = file('/etc/passwd');
         foreach ($passwd as $line) {
             if (preg_match("/^$user:/", $line)) { # the user is from passwd


### PR DESCRIPTION
Do not append the domain suffix, if user name already has it.

NethServer/dev#5203