### PR TITLE
Fix service boot order

### DIFF
--- a/root/usr/lib/systemd/system/nethserver-config-network.service
+++ b/root/usr/lib/systemd/system/nethserver-config-network.service
@@ -2,14 +2,14 @@
 Description=Reconfigure newtork interfaces
 Documentation=https://github.com/NethServer/nethserver-base
 ConditionPathExists=!/var/spool/first-boot
-After=nethserver-system-init.service
-Before=getty.target
+ConditionFileNotEmpty=/var/lib/nethserver/db/networks
+After=network-online.target
+RefuseManualStart=true
+RefuseManualStop=true
 
 [Service]
 Type=oneshot
 ExecStart=/sbin/e-smith/nethserver-config-network
-StandardOutput=tty
-TTYReset=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/root/usr/lib/systemd/system/nethserver-system-init.service
+++ b/root/usr/lib/systemd/system/nethserver-system-init.service
@@ -1,9 +1,12 @@
 [Unit]
 Description=Initialize NethServer configuration
 Documentation=https://github.com/nethesis/nethserver-base
-After=network.service
-Before=getty.target
 ConditionPathExists=/var/spool/first-boot
+After=network-online.target
+DefaultDependencies=false
+Conflicts=shutdown.target
+RefuseManualStart=true
+RefuseManualStop=true
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Do not depend on getty services to start system-init at first boot, or
config-network in other cases. Wait until network-online.target has been
reached, to ensure each network interface is assigned its IP.
