### PR TITLE
Web UI: hide pppoe role from network services

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/NetworkServices/Modify.php
+++ b/root/usr/share/nethesis/NethServer/Module/NetworkServices/Modify.php
@@ -37,7 +37,7 @@ class Modify extends \Nethgui\Controller\Table\Modify
         if ($this->zones) {
             return $this->zones;
         }
-        $invalid_roles = array('bridged', 'alias', 'slave', 'xdsl');
+        $invalid_roles = array('bridged', 'alias', 'slave', 'pppoe');
         $networks = $this->getPlatform()->getDatabase('networks')->getAll();
         $this->zones['red'] = ''; # always enable red
         foreach ($networks as $key => $values) {


### PR DESCRIPTION
The ``xdsl`` role doesn't exists, the right value to hide from the web interface is ``pppoe``.

NethServer/dev#5310