### PR TITLE
Fix password cleanup in first config wizard

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/FirstConfigWiz/RootPassword.php
+++ b/root/usr/share/nethesis/NethServer/Module/FirstConfigWiz/RootPassword.php
@@ -67,12 +67,12 @@ class RootPassword extends \NethServer\Tool\ChangePassword implements \Nethgui\C
         }
         $this->setUserName('root');
         parent::bind($request);
+        $this->stash->setAutoUnlink(FALSE);
     }
 
     public function process()
     {
         if ($this->getRequest()->isMutation()) {
-            $this->stash->setAutoUnlink(FALSE)->store($this->parameters['newPassword']);
             $this->getParent()->storeAction(array(
                 'message' => array(
                     'module' => $this->getIdentifier(),


### PR DESCRIPTION
The password file creation occurs two times, but only the last instance
is correctly shredded. This fix produces only one temporary file that is
erased by password-modify event.

NethServer/dev#5314