### PR TITLE
Avoid bad substring matches

### DIFF
--- a/root/etc/e-smith/events/actions/interface-rename
+++ b/root/etc/e-smith/events/actions/interface-rename
@@ -35,7 +35,7 @@ sub update_refs {
 
     foreach (glob('/var/lib/nethserver/db/*')) {
         if ($_ ne '/var/lib/nethserver/db/networks') {
-            system("sed -i 's/$old/$new/g' $_");
+            system("sed -i 's/\b$old\b/$new/g' $_");
         }
     }
 }


### PR DESCRIPTION
Match interface name on word boundaries like spaces, and symbols ``,:;|``...

NethServer/dev#5314