### PR TITLE
Rename devices unconditionally

### DIFF
--- a/root/etc/e-smith/events/actions/interface-rename
+++ b/root/etc/e-smith/events/actions/interface-rename
@@ -1,4 +1,25 @@
 #!/usr/bin/perl
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
 use esmith::NetworksDB;
 use esmith::ConfigDB;
 

--- a/root/etc/e-smith/events/actions/interface-rename
+++ b/root/etc/e-smith/events/actions/interface-rename
@@ -25,7 +25,7 @@ while ($i < $argnum) {
         die("Empty parameters");
     }
 
-    rename_network_interface($old, $new);
+    update_refs($old, $new);
 }
 
 
@@ -33,23 +33,9 @@ sub update_refs {
     my $old = shift;
     my $new = shift;
 
+    warn "[NOTICE] Rename interface $old -> $new\n";
     foreach (glob('/var/lib/nethserver/db/*')) {
         system("sed -i 's/\\b$old\\b/$new/g' $_");
     }
 }
 
-sub rename_network_interface {
-    my $old = shift;
-    my $new = shift;
-
-    my $ndb = esmith::NetworksDB->open();
-    my $old_r = $ndb->get($old) || undef;
-    my $new_r = $ndb->get($new) || undef;
-    if ( ! defined($old_r) || ! defined($new_r) ) {
-        return;
-    }
-    print "Rename $old -> $new\n";
-    $new_r->merge_props($old_r->props);
-    $old_r->delete();
-    update_refs($old, $new);
-}


### PR DESCRIPTION
When the ``networks`` db is extracted from the config-backup archive, it does not contain the current interface names.

Here ``$new_r`` is always undefined:

https://github.com/NethServer/nethserver-base/blob/288095d5cd4bb7ae86c80d3f55474379f5b9032a/root/etc/e-smith/events/actions/interface-rename#L48 

NethServer/dev#5334