### PR TITLE
Do not overwrite existing interfaces

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/NetworkAdapter/ConfirmInterfaceCreation.php
+++ b/root/usr/share/nethesis/NethServer/Module/NetworkAdapter/ConfirmInterfaceCreation.php
@@ -40,23 +40,24 @@ class ConfirmInterfaceCreation extends \Nethgui\Controller\Table\AbstractAction
         $this->declareParameter('device', FALSE, array($this, 'getNewDeviceName'));
     }
 
-    private function countType($type)
+    private function generateDeviceName($type, $template)
     {
-        $counter = 0;
-        foreach ($this->getAdapter() as $key => $props) {
-            if ($props['type'] == $type) {
-                $counter += 1;
+        $interfaces = $this->getPlatform()->getDatabase('networks')->getAll($type);
+        for($i = 0; $i <= count($interfaces); $i++) {
+            $ifname = sprintf($template, $i);
+            if (!isset($interfaces[$ifname])) {
+                return $ifname;
             }
         }
-        return $counter;
+        return sprintf($template, 0);
     }
 
     public function getNewDeviceName()
     {
         if ($this->parameters['type'] === 'bridge') {
-            return sprintf('br%d', $this->countType('bridge'));
+            return $this->generateDeviceName('bridge', 'br%d');
         } elseif ($this->parameters['type'] === 'bond') {
-            return sprintf('bond%d', $this->countType('bond'));
+            return $this->generateDeviceName('bond', 'bond%d');
         } elseif ($this->parameters['type'] === 'vlan') {
             return sprintf('%s.%s', $this->parameters['vlan'], $this->parameters['vlanTag']);
         }


### PR DESCRIPTION
Fix the new logical interface name generation. For instance, if br1
already exists but br0 not, the next bridge is named br1 and overwrites
the existing one. Instead, the commited code always finds a free interface name.

See commit https://github.com/NethServer/nethserver-base/blob/eefe2157af5ad03070233d5eb6da749b1f764677/root/usr/share/nethesis/NethServer/Module/NetworkAdapter/ConfirmInterfaceCreation.php#L66-L73 for the implementation.

NethServer/dev#5331