### PR TITLE
Show TODO again if RenameInterface fails 

### DIFF
--- a/root/etc/nethserver/todos.d/10eth-unmapped
+++ b/root/etc/nethserver/todos.d/10eth-unmapped
@@ -72,7 +72,7 @@ if(len(unmapped_interfaces) > 0):
                 "url": '/NetworkAdapter'
             },
             "icon": "bolt",
-            "text": gettext.gettext('A role must be assigned to an existing network card otherwise it must be released')
+            "text": gettext.gettext('A role must be assigned to an existing network card otherwise the role must be released')
         }
     json.dump(msg, sys.stdout)
 

--- a/root/etc/nethserver/todos.d/10eth-unmapped
+++ b/root/etc/nethserver/todos.d/10eth-unmapped
@@ -24,28 +24,55 @@ import gettext
 import json
 import os
 import sys
+import subprocess
 
-out = ''
+def get_free_interfaces():
+    interfaces = {}
+    with subprocess.Popen(['/usr/libexec/nethserver/nic-info'], stdout=subprocess.PIPE).stdout as nic_info:
+        for line in nic_info:
+            interfaces[line.split(',')[0]] = {}
+    
+    ndb = json.load(subprocess.Popen(['/sbin/e-smith/db', 'networks', 'getjson'], stdout=subprocess.PIPE).stdout, 'UTF-8')
+    for record in ndb:
+        if record['type'] == 'ethernet' \
+                and 'role' in record['props'] \
+                and record['props']['role'] \
+                and record['name'] in interfaces:
+            interfaces.pop(record['name'], None)
+
+    return list(interfaces.keys())
+
+out_unmapped = ''
 
 try:
-    out = os.popen('/usr/libexec/nethserver/eth-unmapped').read()
+    out_unmapped = subprocess.Popen(['/usr/libexec/nethserver/eth-unmapped'], stdout=subprocess.PIPE).stdout.read()
 except:	
     pass
 
-if(not out):
+if(not out_unmapped):
     exit(1)
 
-unmapped_interfaces = json.loads(out, 'UTF-8')
+unmapped_interfaces = json.loads(out_unmapped, 'UTF-8')
 
 if(len(unmapped_interfaces) > 0):
     gettext.textdomain('nethserver-base')
-    msg = {
-        "action": {
-            "label": gettext.ngettext('Assign role to network interface', 'Assign roles to network interfaces', len(unmapped_interfaces)).format(len(unmapped_interfaces)),
-            "url": '/NetworkAdapter?renameInterface'
-        },
-        "icon": "bolt",
-        "text": gettext.ngettext('A role must be assigned to a new network card', 'There are {0} roles to be assigned to network cards'  , len(unmapped_interfaces)).format(len(unmapped_interfaces))
-    }
+    if len(get_free_interfaces()) > 0:
+        msg = {
+            "action": {
+                "label": gettext.ngettext('Assign role to network interface', 'Assign roles to network interfaces', len(unmapped_interfaces)).format(len(unmapped_interfaces)),
+                "url": '/NetworkAdapter?renameInterface'
+            },
+            "icon": "bolt",
+            "text": gettext.ngettext('A role must be assigned to a new network card', 'There are {0} roles to be assigned to network cards'  , len(unmapped_interfaces)).format(len(unmapped_interfaces))
+        }
+    else:
+        msg = {
+            "action": {
+                "label": gettext.ngettext('Release role from old network interface', 'Release roles from old network interfaces', len(unmapped_interfaces)).format(len(unmapped_interfaces)),
+                "url": '/NetworkAdapter'
+            },
+            "icon": "bolt",
+            "text": gettext.gettext('A role must be assigned to an existing network card otherwise it must be released')
+        }
     json.dump(msg, sys.stdout)
-	    
+

--- a/root/usr/share/nethesis/NethServer/Module/NetworkAdapter.php
+++ b/root/usr/share/nethesis/NethServer/Module/NetworkAdapter.php
@@ -298,6 +298,9 @@ class NetworkAdapter extends \Nethgui\Controller\TableController
         parent::prepareView($view);
         if($this->getRequest()->hasParameter('renameSuccess')) {
             $view->getCommandList('read')->show();
+        } elseif($this->getRequest()->hasParameter('renameFailure')) {
+            $view->getCommandList('read')->show();
+            $view->getCommandList('read')->sendQuery($view->getModuleUrl('/AdminTodo?notifications'));
         }
     }
 }

--- a/root/usr/share/nethesis/NethServer/Module/NetworkAdapter/RenameInterface.php
+++ b/root/usr/share/nethesis/NethServer/Module/NetworkAdapter/RenameInterface.php
@@ -110,6 +110,11 @@ class RenameInterface extends \Nethgui\Controller\AbstractController implements 
                     'url' => $view->getModuleUrl('/NetworkAdapter?renameSuccess'),
                     'freeze' => TRUE,
             )));
+            $this->getPlatform()->setDetachedProcessCondition('failure', array(
+                'location' => array(
+                    'url' => $view->getModuleUrl('/NetworkAdapter?renameFailure'),
+                    'freeze' => TRUE,
+            )));
         }
     }
 


### PR DESCRIPTION
- Do not send the user to RenameInterface page if all NICs are already mapped
- If the interface-update event fails for any reason, return to the main NetworkAdapter page and repeat the procedure from the beginning

NethServer/dev#5428