### PR TITLE
Fix custom cert upload

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -237,7 +237,7 @@ event_actions('system-shutdown', qw(
 $event = "certificate-upload";
 
 event_actions($event, qw(
-    nethserver-certificate-upload	15
+    nethserver-certificate-upload 03
 ));
 
 templates2events('/etc/backup-config.d/nethserver-certificates.include', $event);


### PR DESCRIPTION
Expand config backup template after the uploaded cert has been installed
under /etc/pki

NethServer/dev#5442