### PR TITLE
network config: do not check carrier on boot

### DIFF
--- a/root/usr/lib/systemd/system/nethserver-config-network.service
+++ b/root/usr/lib/systemd/system/nethserver-config-network.service
@@ -9,6 +9,7 @@ RefuseManualStop=true
 
 [Service]
 Type=oneshot
+Environment=SKIPCARRIER=1
 ExecStart=/sbin/e-smith/nethserver-config-network
 
 [Install]

--- a/root/usr/libexec/nethserver/nic-info
+++ b/root/usr/libexec/nethserver/nic-info
@@ -105,14 +105,17 @@ for card in ${cards[@]}; do
 	model=`/bin/lsusb -s $bus:$dev | cut -d':' -f3 | cut -c 6-`
     fi
 
-    link=$(cat /sys/class/net/$card/carrier 2>/dev/null)
-    if [ $? != 0 ]; then
-	/sbin/ip link set $card up 2>/dev/null
-	link=$(cat /sys/class/net/$card/carrier 2>/dev/null)
-	speed=$(cat /sys/class/net/$card/speed 2>/dev/null)
-	/sbin/ip link set $card down 2>/dev/null
-    else
-	speed=$(cat /sys/class/net/$card/speed 2>/dev/null)
+    SKIPCARRIER="${SKIPCARRIER:-0}"
+    if [ ${SKIPCARRIER} -eq 0 ]; then
+        link=$(cat /sys/class/net/$card/carrier 2>/dev/null)
+        if [ $? != 0 ]; then
+	    /sbin/ip link set $card up 2>/dev/null
+	    link=$(cat /sys/class/net/$card/carrier 2>/dev/null)
+	    speed=$(cat /sys/class/net/$card/speed 2>/dev/null)
+	    /sbin/ip link set $card down 2>/dev/null
+        else
+	    speed=$(cat /sys/class/net/$card/speed 2>/dev/null)
+        fi
     fi
 
     echo $card,${hwaddr//,/ },${type//,/ },${model//,/ },${driver//,/ },$speed,$link


### PR DESCRIPTION
Some servers, on power on, are slow on setting up the link of ethernet interfaces.
The problem is probably generated by a combination of ethernet driver and the hardware itself.

During the startup, the `nethserver-config-network` searches for new attached network interfaces to be added inside the `networks` db. Such script, uses `/usr/libexec/nethserver/nic-info` helper to list currently available ethernet interfaces.
The same helper is invoked also from the UI to see the status of all configured network cards. If a network card has no carrier, the script tries to bring it up the for retrieving the card speed.
After speed detection, the carrier is set back to the original down state.

When invoked during the boot process, the helper may generate a race condition bringing down the carrier of a ethernet interface already configured by `network` init script.