### PR TITLE
New default NsReleaseLock prop value

### DIFF
--- a/root/etc/e-smith/db/configuration/defaults/sysconfig/NsReleaseLock
+++ b/root/etc/e-smith/db/configuration/defaults/sysconfig/NsReleaseLock
@@ -1,0 +1,1 @@
+disabled

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_PackageManager.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_PackageManager.php
@@ -48,7 +48,6 @@ $L['NsReleaseLock_enabled_label'] = 'Locked';
 $L['NsReleaseLock_enabled_description'] = 'Limit updates to repositories specific to version ${0}. Other repositories are considered only when new modules are installed';
 $L['BackToModules_label'] = 'Back';
 $L['Save_label'] = 'Save';
-$L['NsReleaseLock_policy_warning'] = 'Choose the software updates origin';
 $L['DistroUpgrade_header'] = 'Software center - distro upgrade';
 $L['DistroUpgradeAvailable_warning'] = '${product} ${version} is available';
 $L['DistroUpgrade_label'] = 'Upgrade';

--- a/root/usr/share/nethesis/NethServer/Module/PackageManager.php
+++ b/root/usr/share/nethesis/NethServer/Module/PackageManager.php
@@ -51,10 +51,9 @@ class PackageManager extends \Nethgui\Controller\CompositeController
     {
         $firstModuleIdentifier = 'Modules';
         $db = $this->getPlatform()->getDatabase('configuration');
-        $nsReleaseLock = $db->getProp('sysconfig', 'NsReleaseLock');
         $nsVersion = $db->getProp('sysconfig', 'Version');
         $sbVersion = $db->getProp('subscription', 'NsRelease');
-        if($nsVersion && $sbVersion && version_compare($sbVersion, $nsVersion, '>') && $nsReleaseLock == 'enabled') {
+        if($nsVersion && $sbVersion && version_compare($sbVersion, $nsVersion, '>')) {
             $firstModuleIdentifier = 'DistroUpgrade';
         }
 

--- a/root/usr/share/nethesis/NethServer/Module/PackageManager.php
+++ b/root/usr/share/nethesis/NethServer/Module/PackageManager.php
@@ -54,9 +54,7 @@ class PackageManager extends \Nethgui\Controller\CompositeController
         $nsReleaseLock = $db->getProp('sysconfig', 'NsReleaseLock');
         $nsVersion = $db->getProp('sysconfig', 'Version');
         $sbVersion = $db->getProp('subscription', 'NsRelease');
-        if( ! $nsReleaseLock) {
-            $firstModuleIdentifier = 'Configuration';
-        } elseif($nsVersion && $sbVersion && version_compare($sbVersion, $nsVersion, '>') && $nsReleaseLock == 'enabled') {
+        if($nsVersion && $sbVersion && version_compare($sbVersion, $nsVersion, '>') && $nsReleaseLock == 'enabled') {
             $firstModuleIdentifier = 'DistroUpgrade';
         }
 

--- a/root/usr/share/nethesis/NethServer/Module/PackageManager/Configuration.php
+++ b/root/usr/share/nethesis/NethServer/Module/PackageManager/Configuration.php
@@ -23,7 +23,7 @@
 namespace NethServer\Module\PackageManager;
 use Nethgui\System\PlatformInterface as Validate;
 
-class Configuration extends \Nethgui\Controller\Collection\AbstractAction implements \Nethgui\Component\DependencyConsumer
+class Configuration extends \Nethgui\Controller\Collection\AbstractAction
 {
     public function initialize()
     {
@@ -80,11 +80,6 @@ class Configuration extends \Nethgui\Controller\Collection\AbstractAction implem
         }
         if($this->getRequest()->isValidated()) {
             $view->getCommandList()->show();
-            $db = $this->getPlatform()->getDatabase('configuration');
-            $nsReleaseLock = $db->getProp('sysconfig', 'NsReleaseLock');
-            if( ! $nsReleaseLock) {
-                $this->notifications->warning($view->translate('NsReleaseLock_policy_warning'));
-            }
         }
         if ($this->getRequest()->isMutation()) {
             $this->getPlatform()->setDetachedProcessCondition('success', array(
@@ -95,14 +90,4 @@ class Configuration extends \Nethgui\Controller\Collection\AbstractAction implem
         }
     }
 
-    public function setUserNotifications(\Nethgui\Model\UserNotifications $n)
-    {
-        $this->notifications = $n;
-        return $this;
-    }
-
-    public function getDependencySetters()
-    {
-        return array('UserNotifications' => array($this, 'setUserNotifications'));
-    }
 }


### PR DESCRIPTION
By default it is now "disabled": removed the UI logic that forces the
selection of the Software updates origin

NethServer/dev#5505