### PR TITLE
Sanitize uploaded SSL certificate

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-certificate-upload
+++ b/root/etc/e-smith/events/actions/nethserver-certificate-upload
@@ -28,37 +28,39 @@ KEY=$4
 CHAIN=$5
 DST=/etc/pki/tls/
 
+# If we exit early, clean up intermediate files:
+trap "rm -f ${DST}/certs/${NAME}.crt ${DST}/private/${NAME}.key ${DST}/certs/${NAME}-chain.crt" EXIT
+
 if [ -z $NAME ]; then
     echo "[ERROR]: invalid name for certificate"
     exit 1
 fi
 
-openssl x509 -in $CRT -text -noout &>/dev/null
+umask 0022
+openssl x509 -in $CRT 2>/dev/null >${DST}/certs/${NAME}.crt
 if [ $? -gt 0 ]; then
     echo "[ERROR]: invalid certificate '$CRT'"
     exit 1
 fi
 
-openssl rsa -in $KEY -text -noout &>/dev/null
+umask 0077
+openssl rsa -in $KEY 2>/dev/null >${DST}/private/${NAME}.key
 if [[ $? != 0 ]]; then
-    openssl ecparam -in $KEY -text -noout &>/dev/null
+    openssl ecparam -in $KEY 2>/dev/null >${DST}/private/${NAME}.key
     if [[ $? != 0 ]]; then
         echo "[ERROR]: invalid private key '$KEY'"
         exit 1
     fi
 fi
 
-cp -f $CRT $DST/certs/$NAME.crt
-chmod 0644 $DST/certs/$NAME.crt
-cp -f $KEY $DST/private/$NAME.key
-chmod 0600 $DST/private/$NAME.key
-
+umask 0022
 if [[ -n "$CHAIN" && -s "$CHAIN" ]]; then
-    openssl x509 -in $CHAIN -text -noout &>/dev/null
+    openssl x509 -in $CHAIN 2>/dev/null >${DST}/certs/${NAME}-chain.crt
     if [ $? -gt 0 ]; then
         echo "[ERROR]: invalid chain file '$CHAIN'"
         exit 1
     fi
-    cp -f $CHAIN "$DST/certs/$NAME"-chain.crt
-    chmod 0644 "$DST/certs/$NAME"-chain.crt
 fi
+
+# Remove error cleanup procedure handler:
+trap - EXIT


### PR DESCRIPTION
Sanitize the certificates and private key file contents, by passing them through the `openssl` command. 

Instead of just copying the uploaded files, process and filter them with `openssl`. This approach ensures line endings are consistent.

----

The original request comes from https://community.nethserver.org/t/chat-application-will-not-work-how-do-we-get-this-setup/7433/12. Some applications fail if the uploaded certificate/private key does not end with an EOL sequence. 

As we're working to SSL upload validation for ECC certificate support, I propose to fix that issue here.

This PR overrides the existing project card opened by @Stell0 

NethServer/dev#5509