### PR TITLE
Fix chain file and ECC key validators

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-certificate-upload
+++ b/root/etc/e-smith/events/actions/nethserver-certificate-upload
@@ -46,7 +46,7 @@ fi
 umask 0077
 openssl rsa -in $KEY 2>/dev/null >${DST}/private/${NAME}.key
 if [[ $? != 0 ]]; then
-    openssl ecparam -in $KEY 2>/dev/null >${DST}/private/${NAME}.key
+    openssl ec -in $KEY 2>/dev/null >${DST}/private/${NAME}.key
     if [[ $? != 0 ]]; then
         echo "[ERROR]: invalid private key '$KEY'"
         exit 1

--- a/root/etc/e-smith/validators/actions/rsa-key
+++ b/root/etc/e-smith/validators/actions/rsa-key
@@ -24,7 +24,7 @@ FILE=$1
 
 openssl rsa -in $FILE -text -noout &>/dev/null
 if [[ $? != 0 ]]; then
-    openssl ecparam -in $FILE -text -noout &>/dev/null
+    openssl ec -in $FILE -noout &>/dev/null
     if [[ $? != 0 ]]; then
         exit 1
     fi

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Pki.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Pki.php
@@ -45,7 +45,7 @@ $L['UploadKey_label'] = 'Private key';
 $L['UploadChain_label'] = 'Chain file (optional)';
 $L['UploadName_label'] = 'Name';
 
-$L['valid_platform,pem-certificate,pem-certificate,1'] = 'X.509 certificate';
-$L['valid_platform,rsa-key,rsa-key,1'] = 'Private RSA key';
+$L['valid_platform,pem-certificate,pem-certificate,1'] = 'X.509 certificate (PEM encoding)';
+$L['valid_platform,rsa-key,rsa-key,1'] = 'RSA or EC private key (PEM encoding)';
 
 $L['vaild_UploadName_file_exists'] = 'The file already exists';

--- a/root/usr/share/nethesis/NethServer/Module/Pki/Upload.php
+++ b/root/usr/share/nethesis/NethServer/Module/Pki/Upload.php
@@ -52,6 +52,10 @@ class Upload extends \Nethgui\Controller\Table\AbstractAction
             $report->addValidationError($this, 'UploadKey', $keyValidator);
         }
 
+        if( ! $crtValidator->evaluate($_FILES['chain']['tmp_name'])) {
+            $report->addValidationError($this, 'UploadChain', $crtValidator);
+        }
+
         if(file_exists(sprintf('/etc/pki/tls/certs/%s.crt', $this->parameters['UploadName']))) {
             $report->addValidationErrorMessage($this, 'UploadName', 'vaild_UploadName_file_exists');
         }


### PR DESCRIPTION
* A validation rule for the chain file was completely missing
* The ECC upload procedure extracts the wrong key part (ecparams instead of the private key)

NethServer/dev#5509