### PR TITLE
Check if the TLS policy is compatible

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -250,6 +250,14 @@ validator_actions('rsa-key',
                   'rsa-key' => '10');
 
 #--------------------------------------------------
+# check the certificate compatibility with
+# current TLS policy
+#--------------------------------------------------
+validator_actions('tlspolicy-safetyguard', qw(
+    tlspolicy-ecdsa-cert 10
+));
+
+#--------------------------------------------------
 # actions for proxy-modify event
 #--------------------------------------------------
 event_templates('proxy-modify', qw(

--- a/root/etc/e-smith/validators/actions/tlspolicy-ecdsa-cert
+++ b/root/etc/e-smith/validators/actions/tlspolicy-ecdsa-cert
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+privkey=$1
+tlspolicy=$2
+
+openssl ec -in "${privkey}" -noout &>/dev/null
+if [[ $? == 0 ]]; then
+    if [[ -z ${tlspolicy} ]] || (( ${tlspolicy} >= 20180621 )); then
+        exit 0
+    else
+        exit 3
+    fi
+fi
+
+exit 0

--- a/root/usr/share/nethesis/NethServer/Help/en/NethServer_Module_Pki.rst
+++ b/root/usr/share/nethesis/NethServer/Help/en/NethServer_Module_Pki.rst
@@ -2,47 +2,6 @@
 Server certificate
 ==================
 
-This page shows the currently installed X.509 certificates for TLS/SSL encrypted
-communications.
+The reference is available online at
 
-The :guilabel:`Show` button allows to view certificate information and to set a
-certificate as default.
-
-The :guilabel:`Upload certificate` button allows to upload certificate files.
-
-The :guilabel:`Request Let's Encrypt certificate` button changes the `Let's
-Encrypt`_ configuration and sends out a new certificate request.
-
-The :guilabel:`Edit self-signed certificate` button allows changing the
-self-signed certificate, by generating a new one.
-
-.. _`Let's Encrypt`: https://letsencrypt.org/
-
-Request a new Let's Encrypt certificate
-=======================================
-
-From this page, you can create a new Let's Encrypt (https://letsencrypt.org/)
-valid certificate. This certificate is automatically updated every 60 days.
-
-Notification email
-    This email is used by Let's Encrypt for notifications about certificate.
-    The server checks itself for certificates validity and warns the ``root``
-    user by email if a certificate has expired.
-
-Domains
-    A single Let's Encrypt certificate can be valid for multiple domains and
-    alias. For instance, mail.nethserver.org, web.nethserver.org, etc. Wildcard
-    certificates (\*.nethserver.org) are not supported.
-
-When :guilabel:`REQUEST LET'S ENCRYPT CERTIFICATE` button is clicked, this
-server is tested by Let's Encrypt to ensure that you have the rights to get a
-certificate. The necessary conditions are:
-
-* The server must be reachable from outside at port 80. Make sure your port 80
-  is open to the public Internet (you can check with sites like
-  http://www.canyouseeme.org/)
-
-* The domains that you want the certificate for, must be public domain names
-  associated to server's own public IP. Make sure you have public DNS name
-  pointing to your server (you can check with sites like http://viewdns.info/)
-
+http://docs.nethserver.org/en/v7/base_system.html#server-certificate

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Pki.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Pki.php
@@ -49,4 +49,4 @@ $L['valid_platform,pem-certificate,pem-certificate,1'] = 'X.509 certificate (PEM
 $L['valid_platform,rsa-key,rsa-key,1'] = 'RSA or EC private key (PEM encoding)';
 $L['vaild_UploadName_file_exists'] = 'The file already exists';
 $L['cert_safetyguard_label'] = 'Default certificate selection';
-$L['valid_platform,tlspolicy-safetyguard,tlspolicy-ecdsa-cert,3'] = 'The TLS policy is not compatible with the system ECC certificate';
+$L['valid_platform,tlspolicy-safetyguard,tlspolicy-ecdsa-cert,3'] = 'The selected ECC certificate is not compatible with the current TLS policy';

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Pki.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Pki.php
@@ -47,5 +47,6 @@ $L['UploadName_label'] = 'Name';
 
 $L['valid_platform,pem-certificate,pem-certificate,1'] = 'X.509 certificate (PEM encoding)';
 $L['valid_platform,rsa-key,rsa-key,1'] = 'RSA or EC private key (PEM encoding)';
-
 $L['vaild_UploadName_file_exists'] = 'The file already exists';
+$L['cert_safetyguard_label'] = 'Default certificate selection';
+$L['valid_platform,tlspolicy-safetyguard,tlspolicy-ecdsa-cert,3'] = 'The TLS policy is not compatible with the system ECC certificate';

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_TlsPolicy.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_TlsPolicy.php
@@ -6,3 +6,4 @@ $L['TlsPolicy_header'] = 'TLS policy';
 $L['Policy_label'] = 'Enforced security level';
 $L['Default_policy_label'] = 'Default upstream policy';
 $L['Policy_item_label'] = 'Policy ${0}';
+$L['valid_platform,tlspolicy-safetyguard,tlspolicy-ecdsa-cert,3'] = 'The TLS policy is not compatible with the system ECC certificate';

--- a/root/usr/share/nethesis/NethServer/Module/TlsPolicy.php
+++ b/root/usr/share/nethesis/NethServer/Module/TlsPolicy.php
@@ -42,6 +42,12 @@ class TlsPolicy extends \Nethgui\Controller\AbstractController
         $this->declareParameter('Policy', $this->createValidator()->memberOf('', '20180330', '20180621'), array('configuration', 'tls', 'policy'));
     }
 
+    public function validate(\Nethgui\Controller\ValidationReportInterface $report)
+    {
+        $this->getValidator('Policy')->platform('tlspolicy-safetyguard', $this->getPlatform()->getDatabase('configuration')->getProp('pki', 'KeyFile'));
+        parent::validate($report);
+    }
+
     public function prepareView(\Nethgui\View\ViewInterface $view)
     {
         parent::prepareView($view);


### PR DESCRIPTION
The TLS policy must be validated against the current system certificate
and vice versa to avoid being locked out from Server Manager.

NethServer/dev#5509