### PR TITLE
interface-rename: skip dhcp reservation records

### DIFF
--- a/root/etc/e-smith/events/actions/interface-rename
+++ b/root/etc/e-smith/events/actions/interface-rename
@@ -56,7 +56,8 @@ sub update_refs {
 
     warn "[NOTICE] Rename interface $old -> $new\n";
     foreach (glob('/var/lib/nethserver/db/*')) {
-        system("sed -i 's/\\b$old\\b/$new/g' $_");
+        # Replace strings inside the db, except for MAC address reservation records
+        system("sed -i '/MacAddress/! {s/\\b$old\\b/$new/g}' $_");
     }
 }
 


### PR DESCRIPTION
Avoid replacing interface inside MAC address reservations.

Example of line inside hosts db:

  myhost=local|Description||IpAddress|192.168.1.2|MacAddress|zz:xx:yy:xx:e0:xx

When renaming e0 interface to enps0 the 'e0' string inside the
MacAddress prop shouldn't be replaced.

NethServer/dev#5547