### PR TITLE
Fix exit code if wrong args are given

### DIFF
--- a/root/etc/e-smith/events/actions/interface-rename
+++ b/root/etc/e-smith/events/actions/interface-rename
@@ -27,7 +27,7 @@ shift; # skip event name
 
 my $argnum = @ARGV;
 
-if ($argnum <= 1) {
+if ($argnum == 0) {
     # Nothing to do
     exit 0;
 }


### PR DESCRIPTION
The "shift" operation on line 26 removes the event name: the resulting list must have an even length. A length of 1 at that point is an error.