### PR TITLE
Disabled zeroconf by a prop

### DIFF
--- a/root/etc/e-smith/db/configuration/defaults/sysconfig/ZeroConf
+++ b/root/etc/e-smith/db/configuration/defaults/sysconfig/ZeroConf
@@ -1,0 +1,1 @@
+enabled

--- a/root/etc/e-smith/templates/etc/sysconfig/network/30zeroConf
+++ b/root/etc/e-smith/templates/etc/sysconfig/network/30zeroConf
@@ -1,0 +1,3 @@
+{
+$OUT .= "NOZEROCONF=yes\n" if (($sysconfig{'ZeroConf'}||'') eq 'disabled';
+}


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/5521

not sure for the prop -> `$sysconfig{'ZeroConf'}` what do you think ?


the event are `hostname-modify` or `interface-update`, do we need to add nethserver-base-update ?