### PR TITLE
Arm integration drop smartmontools dependency

### DIFF
--- a/nethserver-base.spec
+++ b/nethserver-base.spec
@@ -7,7 +7,6 @@ Source: %{name}-%{version}.tar.gz
 BuildArch: noarch
 URL: %{url_prefix}/%{name}
 
-Requires: smartmontools
 Requires: bridge-utils
 Requires: sudo
 Requires: nc


### PR DESCRIPTION
NethServer/dev#5610

Many arm-systems  don’t have SMART-enabled diskdrives, causing Smartmontools thowing (non critical) errors. It is a soft requirement and also pulled in by nethserver-smartd. 

nethetserver-smartd is already required in the iso-compsgroup thus impact is minor/none.