### PR TITLE
Arm integration hardwareinfo

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/Dashboard/SystemStatus/Resources.php
+++ b/root/usr/share/nethesis/NethServer/Module/Dashboard/SystemStatus/Resources.php
@@ -91,8 +91,15 @@ class Resources extends \Nethgui\Controller\AbstractController
                 $ret++;
             }
         }
-        $tmp = explode(':',$f[4]);
-
+        // find cpu model name (x86_64 4th, arm 2th line) 
+        foreach ($f as $linenumber => $line) { 
+            if (strpos($line, 'model name') !== false) { 
+              $linemumber++; 
+              break; 
+            } 
+        } 
+        $tmp = explode(':',$f[$linenumber]);
+        
         return array('model' => trim($tmp[1]), 'n' => $ret);
     }
 

--- a/root/usr/share/nethesis/NethServer/Module/Dashboard/SystemStatus/Resources.php
+++ b/root/usr/share/nethesis/NethServer/Module/Dashboard/SystemStatus/Resources.php
@@ -100,6 +100,9 @@ class Resources extends \Nethgui\Controller\AbstractController
     {
         if (file_exists("/sys/devices/virtual/dmi/id/$id")) {
             return file_get_contents("/sys/devices/virtual/dmi/id/$id");
+        // also try to fetch info for devicetree based (arm)devices
+        } elseif (file_exists("/sys/firmware/devicetree/base/model")) {
+            return file_get_contents("/sys/firmware/devicetree/base/model");
         } else {
             return "-";
         }


### PR DESCRIPTION
NethServer/dev#5610

* Return hardware info vendor / name in Dashboard for arm devices:
/sys/devices/virtual/dmi/id/ is not present on device tree based devices,
try to get meaningful info from /sys/firmware/devicetree/base/ 
it is not pretty same value for vendor and name is returned;
KISS for now

*  find cpu model name:
on x86_64 systems first 'model name' is always on the 4th line of /proc/cpuinfo
on arm systems the 2th line.