### PR TITLE
Import YUM repository GPG keys

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -281,6 +281,7 @@ event_actions('post-restore-config', qw(
 #--------------------------------------------------
 event_actions('software-repos-save', qw(
     nethserver-base-software-repos 20
+    nethserver-base-import-repokeys 21
 ));
 
 event_templates('software-repos-save', qw(

--- a/root/etc/e-smith/events/actions/nethserver-base-import-repokeys
+++ b/root/etc/e-smith/events/actions/nethserver-base-import-repokeys
@@ -23,14 +23,29 @@
 major_version=7
 basearch="$(uname -m)"
 base_persistdir="/var/lib/yum/repos/${basearch}/${major_version}"
-umask 077
 
 gpg_tmpdir=$(mktemp -d)
 trap "rm -rf ${gpg_tmpdir}" EXIT
 
 function generate_gpgtemplatedir
 {
+    # Import ALL stored keys:
     cat /etc/pki/rpm-gpg/RPM-GPG-KEY-* | gpg --homedir "${gpg_tmpdir}" --import
+
+    #
+    # Now set GPG trust for only well-known keys
+    # pub  4096R/F4A80EB5 2014-06-23 CentOS-7 Key (CentOS 7 Official Signing Key) <security@centos.org>
+    # pub  2048R/F2EE9D55 2015-10-01 CentOS SoftwareCollections SIG (https://wiki.centos.org/SpecialInterestGroup/SCLo) <security@centos.org>
+    # pub  4096R/352C64E5 2013-12-16 Fedora EPEL (7) <epel@fedoraproject.org>
+    # pub  4096R/39BAF5C1 2016-02-10 NethServer 7 (NethServer 7 Official Signing Key) <security@nethserver.org>
+    #
+    # To see the key id of a file run:
+    #     gpg /etc/pki/rpm-gpg/RPM-GPG-KEY-NethServer-7
+    #     ...
+    #     pub  4096R/39BAF5C1
+    #
+    # Compare the key id with the last 8 chars of the keys below:
+    #
     gpg --homedir "${gpg_tmpdir}" --import-ownertrust <<EOF
 6341AB2753D78A78A7C27BB124C6A8A7F4A80EB5:6:
 C4DBD535B1FBBA14F8BA64A84EB84E71F2EE9D55:6:

--- a/root/etc/e-smith/events/actions/nethserver-base-import-repokeys
+++ b/root/etc/e-smith/events/actions/nethserver-base-import-repokeys
@@ -56,12 +56,24 @@ EOF
 
 for repo in $(grep -i '^[a-z0-9]' /etc/nethserver/eorepo.conf); do
     gpg_homedir="${base_persistdir}/${repo}/gpgdir"
+    gpgro_homedir="${base_persistdir}/${repo}/gpgdir-ro"
     if [[ ! -d "${gpg_homedir}" ]]; then
         if [[ ! -f ${gpg_tmpdir}/pubring.gpg ]]; then
             generate_gpgtemplatedir
         fi
         mkdir -p "${gpg_homedir}"
         cp -af ${gpg_tmpdir}/* "${gpg_homedir}"
-        cp -af "${gpg_homedir}" "${base_persistdir}/${repo}/gpgdir-ro"
+        touch "${gpg_homedir}/gpg.conf"
+
+        cp -af "${gpg_homedir}" "${gpgro_homedir}"
+        cat - > "${gpgro_homedir}/gpg.conf" <<EOF
+lock-never
+no-auto-check-trustdb
+trust-model direct
+no-expensive-trust-checks
+no-permission-warning
+preserve-permission
+EOF
+        chmod -R a+rx "${gpgro_homedir}"
     fi
 done

--- a/root/etc/e-smith/events/actions/nethserver-base-import-repokeys
+++ b/root/etc/e-smith/events/actions/nethserver-base-import-repokeys
@@ -1,0 +1,52 @@
+#!/usr/bin/bash
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+major_version=7
+basearch="$(uname -m)"
+base_persistdir="/var/lib/yum/repos/${basearch}/${major_version}"
+umask 077
+
+gpg_tmpdir=$(mktemp -d)
+trap "rm -rf ${gpg_tmpdir}" EXIT
+
+function generate_gpgtemplatedir
+{
+    cat /etc/pki/rpm-gpg/RPM-GPG-KEY-* | gpg --homedir "${gpg_tmpdir}" --import
+    gpg --homedir "${gpg_tmpdir}" --import-ownertrust <<EOF
+6341AB2753D78A78A7C27BB124C6A8A7F4A80EB5:6:
+C4DBD535B1FBBA14F8BA64A84EB84E71F2EE9D55:6:
+91E97D7C4A5E96F17F3E888F6A2FAEA2352C64E5:6:
+594C3FD8FAE18FF532FEAE239CB28EA039BAF5C1:6:
+EOF
+}
+
+for repo in $(grep -i '^[a-z0-9]' /etc/nethserver/eorepo.conf); do
+    gpg_homedir="${base_persistdir}/${repo}/gpgdir"
+    if [[ ! -d "${gpg_homedir}" ]]; then
+        if [[ ! -f ${gpg_tmpdir}/pubring.gpg ]]; then
+            generate_gpgtemplatedir
+        fi
+        mkdir -p "${gpg_homedir}"
+        cp -af ${gpg_tmpdir}/* "${gpg_homedir}"
+        cp -af "${gpg_homedir}" "${base_persistdir}/${repo}/gpgdir-ro"
+    fi
+done


### PR DESCRIPTION
Only a well-known set of GPG keys is automatically imported.

NethServer/dev#5664

The action code mimics `import_key_to_pubring` function in yum/misc.py