### PR TITLE
network config: do not check carrier for boot/udev

### DIFF
--- a/root/sbin/e-smith/nethserver-config-network
+++ b/root/sbin/e-smith/nethserver-config-network
@@ -139,7 +139,7 @@ sub update_network_db
 {
     my @fields = qw(name type model driver speed link);
     my @free = ();
-    open(LH, '/usr/libexec/nethserver/nic-info |');
+    open(LH, '/usr/libexec/nethserver/nic-info -n|');
     while(my $line = decode('UTF-8', <LH>)) {
         chomp $line;
         my %H = ();
@@ -175,7 +175,7 @@ sub read_free_interfaces
 {
     my @fields = qw(name type model driver speed link);
     my @free = ();
-    open(LH, '/usr/libexec/nethserver/nic-info |');    
+    open(LH, '/usr/libexec/nethserver/nic-info -n|');
     while(my $line = decode('UTF-8', <LH>)) {
 	chomp $line;
 	my %H = ();

--- a/root/usr/libexec/nethserver/nic-info
+++ b/root/usr/libexec/nethserver/nic-info
@@ -20,6 +20,24 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+# Options:
+# -n : do not check carrier
+#
+usage() { echo "Usage: $0 [-n]" 1>&2; exit 1; }
+
+check_carrier=1
+while getopts ":n" o; do
+    case "${o}" in
+        n)
+            check_carrier=0
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
 if [ "x${1}" == "x" ]; then
     cards=($(ls -A -1 /sys/class/net))
 else
@@ -105,14 +123,16 @@ for card in ${cards[@]}; do
 	model=`/bin/lsusb -s $bus:$dev | cut -d':' -f3 | cut -c 6-`
     fi
 
-    link=$(cat /sys/class/net/$card/carrier 2>/dev/null)
-    if [ $? != 0 ]; then
-	/sbin/ip link set $card up 2>/dev/null
-	link=$(cat /sys/class/net/$card/carrier 2>/dev/null)
-	speed=$(cat /sys/class/net/$card/speed 2>/dev/null)
-	/sbin/ip link set $card down 2>/dev/null
-    else
-	speed=$(cat /sys/class/net/$card/speed 2>/dev/null)
+    if [ $check_carrier -eq 1 ]; then
+        link=$(cat /sys/class/net/$card/carrier 2>/dev/null)
+        if [ $? != 0 ]; then
+            /sbin/ip link set $card up 2>/dev/null
+            link=$(cat /sys/class/net/$card/carrier 2>/dev/null)
+            speed=$(cat /sys/class/net/$card/speed 2>/dev/null)
+            /sbin/ip link set $card down 2>/dev/null
+        else
+            speed=$(cat /sys/class/net/$card/speed 2>/dev/null)
+        fi
     fi
 
     echo $card,${hwaddr//,/ },${type//,/ },${model//,/ },${driver//,/ },$speed,$link


### PR DESCRIPTION
Some servers, on power on, are slow on setting up the link of ethernet interfaces.
The problem is probably generated by a combination of ethernet driver and the hardware itself.

During the startup, the `nethserver-config-network` searches for new attached network interfaces to be added inside the `networks` db. Such script, uses `/usr/libexec/nethserver/nic-info` helper to list currently available ethernet interfaces.
The same helper is invoked also from the UI to see the status of all configured network cards. If a network card has no carrier, the script tries to bring it up the for retrieving the card speed.
After speed detection, the carrier is set back to the original down state.

When invoked during the boot process, the helper may generate a race condition bringing down the carrier of a ethernet interface already configured by `network` init script.

Replaces #154 

NethServer/dev#5714