### PR TITLE
Do not trust the config DB

### DIFF
--- a/root/etc/e-smith/templates/etc/yum/vars/nsrelease/00default
+++ b/root/etc/e-smith/templates/etc/yum/vars/nsrelease/00default
@@ -5,7 +5,14 @@
    #              known implementors: nethserver-subscription
    #
 
-   our $release = $sysconfig{'Version'};
+   our $release = do {
+        # Read from filesystem because the config DB can be overridden
+        # by the "pre-restore-config" event:
+        open my $nsh, "<", '/etc/e-smith/db/configuration/force/sysconfig/Version';
+        <$nsh>;
+   };
+
+   chomp $release;
 
    '';
 }


### PR DESCRIPTION
Always read the current system version from the filesystem

During pre-restore-config the ns6 DB is temporarily restored to extract
the systemId and repo configuration: the sysconfig/Version prop value is
6.x.

https://github.com/NethServer/dev/issues/5724