### PR TITLE
Add proxy environment variables in uppercase

### DIFF
--- a/root/etc/e-smith/templates/etc/profile.d/nethserver_proxy.sh/10base
+++ b/root/etc/e-smith/templates/etc/profile.d/nethserver_proxy.sh/10base
@@ -12,8 +12,11 @@
         }
         $OUT .= "$proxy_host:$proxy_port\"\n";
         $OUT .= "https_proxy=\$http_proxy\n";
+        $OUT .= "HTTP_PROXY=\$http_proxy\n";
+        $OUT .= "HTTPS_PROXY=\$http_proxy\n";
         $OUT .= "export http_proxy\n";
         $OUT .= "export https_proxy\n";
+        $OUT .= "export HTTP_PROXY\n";
+        $OUT .= "export HTTPS_PROXY\n";
     }
 }
-


### PR DESCRIPTION
According to this: https://community.letsencrypt.org/t/certbot-behind-a-forward-proxy/49484/4
certbot makes use of HTTPS_PROXY environment variable to access the internet through a proxy, so we also need to add proxy environment variables in uppercase

More information here
https://community.nethserver.org/t/missing-proxy-enviroment-variables/12938/1