### PR TITLE
Do not die if STDOUT is closed

### DIFF
--- a/root/usr/libexec/nethserver/pkgaction
+++ b/root/usr/libexec/nethserver/pkgaction
@@ -40,8 +40,11 @@ json_output = False
 def joutput(data):
     global json_output
     if json_output:
-        print(json.dumps(data))
-        sys.stdout.flush()
+        try:
+            json.dump(data, sys.stdout)
+            sys.stdout.flush()
+        except:
+            pass
 
 def warning(*objs):
     print(*objs, file=sys.stderr)


### PR DESCRIPTION
A Cockpit session may be closed suddenly with all its file descriptors.
pkgaction must ignore the IO error and complete the YUM transaction.

NethServer/dev#6002