### PR TITLE
interface-rename: support --skip-network option

### DIFF
--- a/root/etc/e-smith/events/actions/interface-rename
+++ b/root/etc/e-smith/events/actions/interface-rename
@@ -32,6 +32,11 @@ if ($argnum == 0) {
     exit 0;
 }
 
+if (defined($ARGV[0]) && $ARGV[0] eq '--skip-network') {
+    # Do not change network config
+    exit 0;
+}
+
 if ( ($argnum) % 2 ) {
     die("Odd numbers of parmeters");
 }


### PR DESCRIPTION
Do not execute any rename if --skip-network option is enabled.

See also NethServer/nethserver-backup-config#41

NethServer/dev#6099