### PR TITLE
pkgaction: do not print duplicated lines

### DIFF
--- a/root/usr/libexec/nethserver/pkgaction
+++ b/root/usr/libexec/nethserver/pkgaction
@@ -47,7 +47,7 @@ def joutput(data):
             if out != last_json_output:
                 json.dump(data, sys.stdout)
                 sys.stdout.flush()
-                last_json_output = json.dumps(data)
+                last_json_output = out
         except:
             pass
 

--- a/root/usr/libexec/nethserver/pkgaction
+++ b/root/usr/libexec/nethserver/pkgaction
@@ -36,13 +36,18 @@ import json
 
 # If True, generate JSON output for cockpit
 json_output = False
+last_json_output = ""
 
 def joutput(data):
     global json_output
+    global last_json_output
     if json_output:
         try:
-            json.dump(data, sys.stdout)
-            sys.stdout.flush()
+            out = json.dumps(data)
+            if out != last_json_output:
+                json.dump(data, sys.stdout)
+                sys.stdout.flush()
+                last_json_output = json.dumps(data)
         except:
             pass
 


### PR DESCRIPTION
When installing large packages, the command prints the same output
hundreds of time potentially filling the stdout buffer when called from
the UI.

Try to avoid such behavior by suppressing duplicated lines.