### PR TITLE
cert-list: read full issuer

### DIFF
--- a/root/usr/libexec/nethserver/cert-list
+++ b/root/usr/libexec/nethserver/cert-list
@@ -157,7 +157,7 @@ sub check
         {
           $cn = $1;
         }
-        elsif($line =~ /Issuer:.*CN=([^\/\n]+)/)
+        elsif($line =~ /Issuer:\s+(.*)$/)
         {
           $issuer= $1;
         }


### PR DESCRIPTION
Let's Encrypt Issuer was displayed just as R3

Before:
![Screenshot from 2020-12-17 16-56-11](https://user-images.githubusercontent.com/804596/102512311-2d068a80-408a-11eb-909e-9c42a5a76268.png)

After:
![Screenshot from 2020-12-17 17-01-22](https://user-images.githubusercontent.com/804596/102512322-3132a800-408a-11eb-8605-6020b287b747.png)
