### PR TITLE
Use nc command from nmap-netcat package

### DIFF
--- a/nethserver-base.spec
+++ b/nethserver-base.spec
@@ -9,7 +9,7 @@ URL: %{url_prefix}/%{name}
 
 Requires: bridge-utils
 Requires: sudo
-Requires: nc
+Requires: nmap-ncat
 Requires: net-tools
 # perl-TimeDate is needed for certificate renew
 Requires: perl-TimeDate

--- a/root/etc/e-smith/events/actions/nethserver-base-conf
+++ b/root/etc/e-smith/events/actions/nethserver-base-conf
@@ -37,3 +37,7 @@ foreach (qw(
     }
 }
 
+#
+# Always use nmap-netcat
+#
+system("/usr/sbin/alternatives --set nmap /usr/bin/ncat")


### PR DESCRIPTION
The new require will prevent the problem on new installation and install the correct package on existing broken installations.
The alternative configuration will fix the link to correct `nc` command.

NethServer/dev#6485