### PR TITLE
Let's Encrypt: support short chain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -406,3 +406,68 @@ Usage: ::
 
  config setprop root EmailAddress myuser@nethserver.org SenderAddress no-reply@nethserver.org
  signal-event notifications-save
+
+Let's Encrypt certificates
+==========================
+
+This package also requests and automatically renews Let's Encrypt (LE) certificates.
+It adds httpd ACME-related configuration for all defined virtual hosts.
+
+The main helper ``/usr/libexec/nethserver/letsencrypt-certs`` can be executed also from command line.
+
+For more info, see: ::
+
+  /usr/libexec/nethserver/letsencrypt-certs -h 
+
+
+Database properties under ``pki`` key inside ``configuration`` database:
+
+- ``LetsEncryptRenewDays``: days to the expiration, the certificate will be renewd when the condition is met
+- ``LetsEncryptMail``: (optional) registration mail for LE notifications
+- ``LetsEncryptDomains``: comma-separated list of domains added to certificate SAN field
+- ``LetsEncryptChallenge``: challenge to use for validating the certificate, default is ``http``.
+  It accepts also values like ``dns-<provider>``. Where ``<provider>`` is the name of the DNS provider.
+  See the full list of available DNS provider plugins by executing ``certbot -h certonly``.
+  More info at https://certbot.eff.org/docs/using.html?highlight=dns#dns-plugins.
+- ``LetsEncryptShortChain``: can be ``enabled`` or ``disabled``. If ``enabled``, the certificate chain will *not*
+  contain the expired DST Root CA X3
+
+DNS challenge
+=============
+
+To use the DNS challenge, follow these steps:
+
+- install the required certbot plugin plugin using yum; to see the list of available package use ``yum search certbot-dns``
+- set ``LetsEncryptChallenge`` property to correct DNS plugin
+- configure all required properties accordingly to plugin documentation
+
+When using the dns challenge, make sure to set extra properties accordingly to certbot configuration.
+All properties for the dns challenge should be in the form ``LetsEncrypt_<certbot_option>``, where
+``<certbot_option>`` is the option specific to certbot DNS plugin.
+
+Digitial Ocean example
+----------------------
+
+1. Install the plugin:
+
+   ::
+
+     yum install python2-certbot-dns-digitalocean
+
+2. Configure the challenge type:
+
+   ::
+
+     config setprop pki LetsEncryptChallenge dns-digitalocean
+
+2. Configure required props accordingly to https://certbot-dns-digitalocean.readthedocs.io/en/stable/:
+   
+   ::
+
+     config setprop pki LetsEncrypt_dns_digitalocean_token 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+
+3. Request certificate for domain ``myserver.nethserver.org``:
+
+   ::
+ 
+     /usr/libexec/nethserver/letsencrypt-certs -v -d myserver.nethserver.org

--- a/nethserver-base.spec
+++ b/nethserver-base.spec
@@ -26,7 +26,7 @@ Obsoletes: nethserver-yum-cron
 
 # letsencrypt dependencies
 Requires: httpd
-Requires: certbot
+Requires: certbot >= 1.11.0-2.el7
 Provides: nethserver-letsencrypt
 Obsoletes: nethserver-letsencrypt
 

--- a/root/etc/e-smith/db/configuration/defaults/pki/LetsEncryptShortChain
+++ b/root/etc/e-smith/db/configuration/defaults/pki/LetsEncryptShortChain
@@ -1,0 +1,1 @@
+enabled

--- a/root/usr/libexec/nethserver/letsencrypt-certs
+++ b/root/usr/libexec/nethserver/letsencrypt-certs
@@ -21,6 +21,7 @@ our $modified = 0;
 # Certificate for FQDN
 our @domains = ();
 my $challenge = $cdb->get_prop('pki', 'LetsEncryptChallenge') || 'http';
+my $short_chain = $cdb->get_prop('pki', 'LetsEncryptShortChain') || 'disabled';
 my $tmp;
 
 $SIG{INT}  = \&restore;
@@ -41,6 +42,7 @@ sub renew {
     my $domains = shift;
     my $challenge = shift;
     my $config = shift || '';
+    my $short_chain = shift || 0;
 
     my $opts = " certonly --text --non-interactive --agree-tos ";
     if (!$mail) {
@@ -68,6 +70,10 @@ sub renew {
     if ($testing) {
         $cmd .= " --test-cert ";
     }
+
+    if ($short_chain) {
+        $cmd .= " --preferred-chain 'ISRG Root X1' "
+    };
 
     if (!$verbose) {
         $cmd .= " --quiet >/dev/null";
@@ -161,6 +167,6 @@ if ($challenge =~ m/^dns/) {
 }
 
 # Renew certificate for all domains
-renew(\@domains, $challenge, $tmp ? $tmp->filename : undef);
+renew(\@domains, $challenge, $tmp ? $tmp->filename : undef, $short_chain);
 
 exit 0;


### PR DESCRIPTION
Add `LetsEncryptShortChain` property under `pki` key.
If the property is enabled, certbot will request a certificate with the shorter chain by using `--preferred-chain 'ISRG Root X1'` option.

With such option the certificate chain will not contain the expired certificate named `DST Root CA X3`.

See also:
- https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
- https://bugzilla.redhat.com/show_bug.cgi?id=1962332
- https://access.redhat.com/articles/6338021

NethServer/dev#6584