### PR TITLE
network-config-reset: fix alias removal

### DIFF
--- a/root/etc/e-smith/events/actions/interface-config-reset
+++ b/root/etc/e-smith/events/actions/interface-config-reset
@@ -43,7 +43,7 @@ for i in $interfaces; do
 done
 
 # remove all aliases
-rm -f $ESMITH_NETWORK_OUT_DIR/ifcfg-*\:? 2>/dev/null
+rm -f $ESMITH_NETWORK_OUT_DIR/ifcfg-*:* 2>/dev/null
 # remove all routes
 rm -f $ESMITH_NETWORK_OUT_DIR/route-* 2>/dev/null
 


### PR DESCRIPTION
Actual bash glob (ifcfg-*\:?) removes only one-digit aliases (ifcfg-eth0:0).

NethServer/dev#6773